### PR TITLE
removed std::string::pop_back from spruce

### DIFF
--- a/thirdParty/spruce/src/spruce.cc
+++ b/thirdParty/spruce/src/spruce.cc
@@ -280,7 +280,7 @@ void spruce::path::normalize()
 {
     std::replace( path_str.begin(), path_str.end(), '\\', '/' );
 
-    if ( path_str.back() == '/' ) path_str.pop_back();
+    if ( path_str.back() == '/' ) path_str = path_str.substr(0, path_str.length()-1);
 }
 
 /*-------------------------------------------------------


### PR DESCRIPTION
Fixes c++11 related build errors on gcc 4.6.